### PR TITLE
Upgrade to version 2023-03-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Output format can take several forms:
  * `Plaintext` : raw text (php object, as returned by print_r)
  
 
-**Shipped version:** 2022.06.14~ynh2
+**Shipped version:** 2023-03-22~ynh2
 
 **Demo:** https://wtf.roflcopter.fr/rss-bridge/
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Output format can take several forms:
  * `Plaintext` : raw text (php object, as returned by print_r)
  
 
-**Shipped version:** 2023-03-22~ynh2
+**Shipped version:** 2023-03-22~ynh1
 
 **Demo:** https://wtf.roflcopter.fr/rss-bridge/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -53,7 +53,7 @@ Output format can take several forms:
  * `Plaintext` : raw text (php object, as returned by print_r)
  
 
-**Version incluse :** 2022.06.14~ynh2
+**Version incluse :** 2023-03-22~ynh2
 
 **Démo :** https://wtf.roflcopter.fr/rss-bridge/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -53,7 +53,7 @@ Output format can take several forms:
  * `Plaintext` : raw text (php object, as returned by print_r)
  
 
-**Version incluse :** 2023-03-22~ynh2
+**Version incluse :** 2023-03-22~ynh1
 
 **Démo :** https://wtf.roflcopter.fr/rss-bridge/
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "RSS-Bridge"
 description.en = "RSS and Atom feed generator for websites that don't have one"
 description.fr = "Générateur de flux RSS et Atom pour les sites Web qui n'en ont pas"
 
-version = "2023-03-22~ynh2"
+version = "2023-03-22~ynh1"
 
 maintainers = ["JimboJoe"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "RSS-Bridge"
 description.en = "RSS and Atom feed generator for websites that don't have one"
 description.fr = "Générateur de flux RSS et Atom pour les sites Web qui n'en ont pas"
 
-version = "2022.06.14~ynh2"
+version = "2023-03-22~ynh2"
 
 maintainers = ["JimboJoe"]
 
@@ -35,8 +35,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://github.com/RSS-Bridge/rss-bridge/archive/refs/tags/2022-06-14.tar.gz"
-        sha256 = "88daee9604adcb2193ee771c260bcf422a806c284a46c4f263d42cf323d42fe1"
+        url = "https://github.com/RSS-Bridge/rss-bridge/archive/refs/tags/2023-03-22.tar.gz"
+        sha256 = "7bc6ad3220ad6a699583be6763aebc39ecb9e3bb2454f3f0add88c1e7ae93cfc"
 
 
     [resources.system_user]


### PR DESCRIPTION
A new update is available. https://github.com/RSS-Bridge/rss-bridge/releases/tag/2023-03-22

This require php7.4 as a minimum, but we switched to php8.x recently so it is fine #57.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
