### PR TITLE
Use full-replace at upgrade to prevent obsolete bridges breaking the app 

### DIFF
--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,0 +1,3 @@
+## Custom bridges
+If you tweaked existing bridges or added custom ones, **you will have to restore them manually after upgrade**. Upgrading to the next version of RSS Bridge will indeed overwrite existing bridges with updated ones (in order to make sure than obsolete bridges are deleted and do not prevent RSS Bridge from working). 
+In this case, it is recommended to back your custom bridges manually (located by default at `/var/www/rss-bridge/bridges/`) prior to upgrading to be on the safest side (although they will be included in the automatic pre-upgrade backup that should also be performed).

--- a/doc/PRE_UPGRADE_fr.md
+++ b/doc/PRE_UPGRADE_fr.md
@@ -1,0 +1,3 @@
+## Bridges personnalisés
+Si vous avez modifié les *bridges* existants ou que vous en avez créé de toutes pièces, vous devrez les **restaurer manuellement une fois la mise à jour effectuée**. Mettre à jour RSS Bridge va en effet supprimer tous les *bridges* existants et les remplacer avec les nouveaux (afin de s'assurer que les *bridges* obsolètes soient supprimés et n'empêche pas RSS Bridge de fonctionner).
+Dans ce cas-ci, il est recommandé de sauvegarder manuellement vos *bridges* personnalisés (situés par défaut dans `/var/www/rss-bridge/bridges/`) avant de faire la mise à jour pour éviter tout problème (bien qu'ils seront inclus dans la sauvegarde automatique d'avant-mise à jour qui devrait également être faite).

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,7 +16,7 @@ ynh_app_setting_set_default --key=php_post_max_size --value=50M
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --keep="whitelist.txt config.ini.php"
+ynh_setup_source --dest_dir="$install_dir" --keep="whitelist.txt config.ini.php" --full_replace=1
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS


### PR DESCRIPTION
## Problem

Obsolete bridges are sometimes removed from upstream, but in current YNH package's upgrade process would be left in the YNH instance. Thus causing issues such as #76 which make the whole app unusable (the issue is not limited to the bridge itself).

## Solution

Use the `--full_replace=1` flag to `ynh_setup_source`.
However that would remove any potential custom bridges tweaked/added by the instance's admin. Hence the pre-ugrade notice added with that PR. 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
